### PR TITLE
Revert "let client raise on unexpected response status"

### DIFF
--- a/priceloop_api/priceloop/auth/priceloop_client.py
+++ b/priceloop_api/priceloop/auth/priceloop_client.py
@@ -16,7 +16,7 @@ class PriceloopClient(AuthenticatedClient):
         self.cookies = {}
         self.headers = {}
         self.verify_ssl = True
-        self.raise_on_unexpected_status = True
+        self.raise_on_unexpected_status = False
         self.auth_state = auth_state
         self.follow_redirects = False
 


### PR DESCRIPTION
This reverts commit 88587e2bdbf1c47deb499c5e18c39001ef53a664.

Same as the original default of the python generator.
